### PR TITLE
Update actions to use sha instead of tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,9 @@ jobs:
           echo ::set-output name=docker_image::jmb12686/cadvisor
       -
         # https://github.com/crazy-max/ghaction-docker-buildx
+        # sha = https://github.com/crazy-max/ghaction-docker-buildx/releases/tag/v1.0.4
         name: Set up Docker Buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+        uses: crazy-max/ghaction-docker-buildx@e193644d92840c3a0d2a80093feff3a0d8d64e7e
         with:
           version: latest
       -

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,9 @@ jobs:
         uses: actions/checkout@v1
       -
         # https://github.com/crazy-max/ghaction-docker-buildx
+        # sha = https://github.com/crazy-max/ghaction-docker-buildx/releases/tag/v1.0.4
         name: Set up Docker Buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+        uses: crazy-max/ghaction-docker-buildx@e193644d92840c3a0d2a80093feff3a0d8d64e7e
         with:
           version: latest
       -


### PR DESCRIPTION
Update crazy-max/ghaction-docker-buildx to use SHA commit instead of mutable tag